### PR TITLE
feat(chart): color-code bars by attendance thresholds

### DIFF
--- a/script.js
+++ b/script.js
@@ -52,7 +52,15 @@ function deleteSubject(index){
 
 function renderChart(){
     const labels = subjects.map(s => s.name);
-    const data = subjects.map(s => ((s.attended / s.total)*100).toFixed(2));
+    const data = subjects.map(s => (s.total > 0 ? (s.attended / s.total) * 100 : 0));
+
+    const barColors = subjects.map(s => {
+        const p = s.total > 0 ? (s.attended / s.total) * 100 : 0;
+        if (p < 75) return '#ff6b6b'; // red
+        if (p < 80) return '#ffa500'; // orange
+        if (p < 85) return '#f6d365'; // yellow
+        return '#43e97b';
+    });
 
     if(attendanceChart) attendanceChart.destroy();
 
@@ -63,7 +71,9 @@ function renderChart(){
             datasets: [{
                 label: 'Attendance %',
                 data: data,
-                backgroundColor: '#4facfe'
+                backgroundColor: barColors,
+                borderColor: barColors,
+                borderWidth: 1
             }]
         },
         options: {


### PR DESCRIPTION
## What: Apply dynamic per-bar colors in the attendance chart based on percentage thresholds.
## Thresholds:
* <75%: red #ff6b6b
* 75–<80%: orange #ffa500
* 80–<85%: yellow #f6d365
* ≥85%: green #43e97b
## How: Compute attendance % per subject and map to a color array used for both backgroundColor and borderColor in Chart.js.
## Why: Improves readability and highlights at-risk subjects at a glance.